### PR TITLE
Fixed: casing of "GitHub"

### DIFF
--- a/EPPlus.WebSampleMvc.NetCore/Views/Home/Index.cshtml
+++ b/EPPlus.WebSampleMvc.NetCore/Views/Home/Index.cshtml
@@ -49,6 +49,6 @@
     <div class="row">
         <div class="col">
             <h3>Clone this repo</h3>
-            <p>You can explore the code in this web app by cloning this <a href="https://github.com/EPPlusSoftware/EPPlus.WebSamples" target="blank">Github repository</a></p>
+            <p>You can explore the code in this web app by cloning this <a href="https://github.com/EPPlusSoftware/EPPlus.WebSamples" target="blank">GitHub repository</a></p>
         </div>
     </div>


### PR DESCRIPTION
Changes:
* Changed casing: `Github` to `GitHub`